### PR TITLE
Remove package.zip from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
       publish-command: pnpm changeset:publish
       language: terraform
       language-version: 1.9.4
-      github-release-files: 'package.zip'
     secrets:
       RUNNER_APP_PRIVATE_KEY: ${{ secrets.RUNNER_APP_PRIVATE_KEY }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "author": "FingerprintJS, Inc (https://fingerprint.com)",
   "description": "Terraform module for Fingerprint Fastly Compute Proxy Integration",
   "scripts": {
-    "prepare-package": "bash scripts/preparePackage.sh",
-    "prechangeset:publish": "pnpm prepare-package",
     "changeset:publish": "changeset publish",
     "changeset:version": "changeset version"
   },

--- a/scripts/preparePackage.sh
+++ b/scripts/preparePackage.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
- zip package.zip main.tf variables.tf modules/download_asset/main.tf modules/download_asset/output.tf modules/download_asset/variables.tf


### PR DESCRIPTION
## Problem

Since switching to immutable GitHub releases, the release workflow was failing whenever it tried to attach `package.zip` as a release asset. Immutable releases don't allow files to be added after the release is published.

## Investigation

`terraform init` works correctly against the official registry. We concluded that this workaround is no longer necessary.